### PR TITLE
refactor: simplify icon component props and remove PropTypes

### DIFF
--- a/scripts/generateIcons.js
+++ b/scripts/generateIcons.js
@@ -127,29 +127,19 @@ const react = async (icons) => {
       }
       const element = `
        import React, {forwardRef} from 'react';
-       import PropTypes from 'prop-types';
 
        ${loopAllVariant(iconsAllVariant)}
 
        ${switchStatementForVariants(iconsAllVariant)}
 
        const ${ComponentName} =
-       forwardRef(({ variant , color, size , ...rest }, ref) => {
+       forwardRef(({ variant = 'Linear', color = 'currentColor', size = '24', ...rest }, ref) => {
           return (
               <svg {...rest} xmlns="http://www.w3.org/2000/svg" ref={ref} width={size} height={size} viewBox="0 0 24 24" fill="none">
               {chooseVariant(variant, color)}
               </svg>)
        });
-       ${ComponentName}.propTypes = {
-        variant: PropTypes.oneOf(['Linear', 'Bold', 'Broken', 'Bulk', 'Outline', 'TwoTone']),
-        color: PropTypes.string,
-        size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-       }
-       ${ComponentName}.defaultProps = {
-        variant: 'Linear',
-        color: 'currentColor',
-        size: '24'
-       }
+
        ${ComponentName}.displayName = '${ComponentName}'
 
        export default ${ComponentName}
@@ -206,7 +196,6 @@ const reactNative = async (icons) => {
       }
       const element = `
          import React, {forwardRef} from 'react';
-         import PropTypes from 'prop-types';
          import Svg, {  Path, G } from 'react-native-svg';
 
          ${loopAllVariant(iconsAllVariant, true)}
@@ -214,22 +203,13 @@ const reactNative = async (icons) => {
          ${switchStatementForVariants(iconsAllVariant)}
 
          const ${ComponentName} =
-         forwardRef(({ variant , color, size , ...rest }, ref) => {
+         forwardRef(({ variant = 'Linear', color = 'currentColor', size = '24', ...rest }, ref) => {
             return (
                 <Svg {...rest} xmlns="http://www.w3.org/2000/svg" ref={ref} width={size} height={size} viewBox="0 0 24 24" fill="none">
                 {chooseVariant(variant, color)}
                 </Svg>)
          });
-         ${ComponentName}.propTypes = {
-          variant: PropTypes.oneOf(['Linear', 'Bold', 'Broken', 'Bulk', 'Outline', 'TwoTone']),
-          color: PropTypes.string,
-          size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-         }
-         ${ComponentName}.defaultProps = {
-          variant: 'Linear',
-          color: 'currentColor',
-          size: '24'
-         }
+
          ${ComponentName}.displayName = '${ComponentName}'
          export default ${ComponentName}
          `;


### PR DESCRIPTION
This pull request includes changes to the `scripts/generateIcons.js` file to simplify the code for generating React and React Native icons by removing `PropTypes` and default props. The most important changes include:

Simplification of React icon generation:

* Removed `PropTypes` and default props from the React icon component. Default values are now set directly in the `forwardRef` function parameters. 

Related: #18 